### PR TITLE
Upgrade goreleaser version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # This is an example goreleaser.yaml file with some sane defaults.
 # Make sure to check the documentation at http://goreleaser.com
+version: 2
 env:
   - CGO_ENABLED=0
 before:


### PR DESCRIPTION
Due to https://github.com/goreleaser/goreleaser/pull/4806

Fixes

![page](https://github.com/QubitPi/packer-plugin-hashicorp-aws/assets/16126939/2cab1a33-b017-41d6-8e0c-a729f6089f31)
